### PR TITLE
#30 feat(wish): 즐겨찾기 목록 조회 UseCase 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/repository/MockWishRepositoryImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/repository/MockWishRepositoryImpl.kt
@@ -1,13 +1,11 @@
 package com.hkjj.heartbreakprice.data.repository
 
-import com.hkjj.heartbreakprice.core.Result
-import com.hkjj.heartbreakprice.domain.model.Product
 import com.hkjj.heartbreakprice.domain.model.WishProduct
 import com.hkjj.heartbreakprice.domain.repository.WishRepository
 
 class MockWishRepositoryImpl : WishRepository {
 
-    private val wishProducts =  mutableListOf(
+    private val wishProducts = mutableListOf(
         WishProduct(
             id = "1",
             name = "갤럭시 S24 울트라 256GB",
@@ -65,12 +63,8 @@ class MockWishRepositoryImpl : WishRepository {
         )
     )
 
-    override suspend fun getWishes(): Result<List<WishProduct>, Exception> {
-        return try {
-            Result.Success(wishProducts.toList())
-        } catch (e: Exception) {
-            Result.Error(e)
-        }
+    override suspend fun getWishes(): List<WishProduct> {
+        return wishProducts.toList()
     }
 
     override suspend fun addToWish(wishProduct: WishProduct) {

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/WishRepository.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/WishRepository.kt
@@ -5,7 +5,7 @@ import com.hkjj.heartbreakprice.domain.model.Product
 import com.hkjj.heartbreakprice.domain.model.WishProduct
 
 interface WishRepository {
-    suspend fun getWishes(): Result<List<WishProduct>, Exception>
+    suspend fun getWishes(): List<WishProduct>
     suspend fun addToWish(wishProduct: WishProduct)
     suspend fun removeFromWishes(productId: String)
     suspend fun updateTargetPrice(productId: String, targetPrice: Int)

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/DeleteWishUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/DeleteWishUseCase.kt
@@ -1,0 +1,17 @@
+package com.hkjj.heartbreakprice.domain.usecase
+
+import com.hkjj.heartbreakprice.core.Result
+import com.hkjj.heartbreakprice.domain.repository.WishRepository
+
+class DeleteWishUseCase(
+    private val wishRepository: WishRepository,
+) {
+    suspend operator fun invoke(productId: String): Result<Unit, Exception> {
+        return try {
+            wishRepository.removeFromWishes(productId)
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetWishesUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetWishesUseCase.kt
@@ -1,0 +1,17 @@
+package com.hkjj.heartbreakprice.domain.usecase
+
+import com.hkjj.heartbreakprice.core.Result
+import com.hkjj.heartbreakprice.domain.model.WishProduct
+import com.hkjj.heartbreakprice.domain.repository.WishRepository
+
+class GetWishesUseCase(
+    private val repository: WishRepository
+) {
+    suspend operator fun invoke(): Result<List<WishProduct>, Exception> {
+        return try {
+            Result.Success(repository.getWishes())
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/component/TargetPriceDialog.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/component/TargetPriceDialog.kt
@@ -1,0 +1,118 @@
+package com.hkjj.heartbreakprice.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.hkjj.heartbreakprice.domain.model.WishProduct
+import java.text.NumberFormat
+import java.util.Locale
+
+@Composable
+fun TargetPriceDialog(
+    wishProduct: WishProduct,
+    onDismiss: () -> Unit,
+    onSave: (Int) -> Unit,
+) {
+    var priceInput by remember { mutableStateOf(wishProduct.targetPrice?.toString() ?: "") }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White)
+        ) {
+            Column(modifier = Modifier.padding(24.dp)) {
+                Text(text = "목표 가격 설정", style = MaterialTheme.typography.titleLarge)
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text("상품명", style = MaterialTheme.typography.labelMedium)
+                Text(wishProduct.name, style = MaterialTheme.typography.bodyMedium)
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Text("현재가", style = MaterialTheme.typography.labelMedium)
+                Text(
+                    "${NumberFormat.getNumberInstance(Locale.KOREA).format(wishProduct.price)}원",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+                OutlinedTextField(
+                    value = priceInput,
+                    onValueChange = { newValue ->
+                        if (newValue.all { it.isDigit() }) {
+                            priceInput = newValue
+                        }
+                    },
+                    label = { Text("목표 가격") },
+                    placeholder = { Text("예: 300000") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text("이 가격 이하로 할인되면 알림을 받습니다", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+
+                Spacer(modifier = Modifier.height(24.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
+                    Button(onClick = onDismiss, colors = ButtonDefaults.textButtonColors()) {
+                        Text("취소")
+                    }
+                    Button(onClick = {
+                        val price = priceInput.toIntOrNull()
+                        if (price != null && price > 0) {
+                            onSave(price)
+                        }
+                    }) {
+                        Text("저장")
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun TargetPriceDialogPreview() {
+    val wishProduct = WishProduct(
+        id = "1",
+        name = "Canon EOS R6 Mark II 바디",
+        price = 3190000,
+        originalPrice = 3500000,
+        image = "https://images.unsplash.com/photo-1579535984712-92fffbbaa266?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjYW1lcmElMjBwaG90b2dyYXBoeXxlbnwxfHx8fDE3NjgzMjQyMTB8MA&ixlib=rb-4.1.0&q=80&w=1080",
+        category = "카메라",
+        shop = "G마켓",
+        targetPrice = 1000000,
+        addedDate = "2026-01-14T14:45:20"
+    )
+
+    TargetPriceDialog(
+        wishProduct = wishProduct,
+        onDismiss = {},
+        onSave = {}
+    )
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/component/WishCard.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/component/WishCard.kt
@@ -1,0 +1,254 @@
+package com.hkjj.heartbreakprice.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DateRange
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.NotificationsOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.hkjj.heartbreakprice.domain.model.WishProduct
+import java.text.NumberFormat
+import java.util.Locale
+
+@Composable
+fun WishCard(
+    wishProduct: WishProduct,
+    targetPriceText: String,
+    targetPriceColor: Color,
+    onTargetPriceButtonClick: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    Card(
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column {
+            // Image Area
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(4f / 3f)
+                    .background(Color.Gray)
+            ) {
+                AsyncImage(
+                    model = wishProduct.image,
+                    contentDescription = wishProduct.name,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+
+                // Badges
+                Row(modifier = Modifier.padding(8.dp)) {
+                    wishProduct.originalPrice?.let { original ->
+                        val discount = ((1 - wishProduct.price.toDouble() / original) * 100).toInt()
+                        Box(
+                            modifier = Modifier
+                                .background(Color.Red, RoundedCornerShape(8.dp))
+                                .padding(horizontal = 6.dp)
+                                .padding(bottom = 4.dp)
+                        ) {
+                            Text(
+                                text = "$discount% 할인",
+                                color = Color.White,
+                                style = MaterialTheme.typography.labelSmall
+                            )
+                        }
+                    }
+                    Spacer(Modifier.width(4.dp))
+
+                    if (targetPriceText.isNotEmpty()) {
+                        Box(
+                            modifier = Modifier
+                                .background(targetPriceColor, RoundedCornerShape(8.dp))
+                                .padding(horizontal = 6.dp)
+                                .padding(bottom = 4.dp)
+                        ) {
+                            Text(
+                                text = targetPriceText,
+                                color = Color.White,
+                                style = MaterialTheme.typography.labelSmall
+                            )
+                        }
+                    }
+                }
+            }
+
+            // Info Area
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .border(1.dp, Color.LightGray, RoundedCornerShape(4.dp))
+                            .padding(horizontal = 6.dp, vertical = 2.dp)
+                    ) {
+                        Text(text = wishProduct.category, style = MaterialTheme.typography.labelSmall)
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Icon(
+                        Icons.Default.DateRange,
+                        contentDescription = null,
+                        modifier = Modifier.size(12.dp),
+                        tint = Color.Gray
+                    )
+                    Text(
+                        text = wishProduct.addedDate.substring(0, 10),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = Color.Gray
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = wishProduct.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(wishProduct.shop, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // Price
+                Text("현재가", style = MaterialTheme.typography.labelSmall, color = Color.Gray)
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    wishProduct.originalPrice?.let {
+                        Text(
+                            text = "${NumberFormat.getNumberInstance(Locale.KOREA).format(it)}원",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Gray,
+                            textDecoration = TextDecoration.LineThrough
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
+                    Text(
+                        text = "${NumberFormat.getNumberInstance(Locale.KOREA).format(wishProduct.price)}원",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                if (wishProduct.targetPrice != null) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text("목표가", style = MaterialTheme.typography.labelSmall, color = Color.Gray)
+                    Text(
+                        text = "${NumberFormat.getNumberInstance(Locale.KOREA).format(wishProduct.targetPrice)}원",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Actions
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(
+                        onClick = onTargetPriceButtonClick,
+                        modifier = Modifier.weight(1f),
+                        contentPadding = PaddingValues(0.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(),
+                        border = androidx.compose.foundation.BorderStroke(1.dp, Color.LightGray),
+                        shape = RoundedCornerShape(4.dp)
+                    ) {
+                        if (wishProduct.targetPrice != null) {
+                            Icon(
+                                Icons.Default.Notifications,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Text("수정", fontSize = 12.sp)
+                        } else {
+                            Icon(
+                                Icons.Default.NotificationsOff,
+                                contentDescription = null,
+                                modifier = Modifier.size(16.dp)
+                            )
+                            Text("목표가", fontSize = 12.sp)
+                        }
+                    }
+
+                    Button(
+                        onClick = onRemove,
+                        colors = ButtonDefaults.textButtonColors(contentColor = Color.Red),
+                        modifier = Modifier.width(32.dp),
+                        contentPadding = PaddingValues(0.dp),
+                        shape = RoundedCornerShape(4.dp)
+                    ) {
+                        Icon(Icons.Default.Delete, contentDescription = "Delete", modifier = Modifier.size(16.dp))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fun getPriceStatus(currentPrice: Int, targetPrice: Int?): Pair<String, Color>? {
+    if (targetPrice == null) return null
+    if (currentPrice <= targetPrice) {
+        return "목표가 도달!" to Color(0xFF22C55E) // Green 500
+    }
+    val diff = ((currentPrice - targetPrice).toFloat() / targetPrice) * 100
+    if (diff <= 10) {
+        return "목표가 근접" to Color(0xFFEAB308) // Yellow 500
+    }
+    return "추적 중" to Color(0xFF3B82F6) // Blue 500
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WishCardPreview() {
+    val wishProduct = WishProduct(
+        id = "1",
+        name = "Canon EOS R6 Mark II 바디",
+        price = 3190000,
+        originalPrice = 3500000,
+        image = "https://images.unsplash.com/photo-1579535984712-92fffbbaa266?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzg4Nzd8MHwxfHNlYXJjaHwxfHxjYW1lcmElMjBwaG90b2dyYXBoeXxlbnwxfHx8fDE3NjgzMjQyMTB8MA&ixlib=rb-4.1.0&q=80&w=1080",
+        category = "카메라",
+        shop = "G마켓",
+        targetPrice = 1000000,
+        addedDate = "2026-01-14T14:45:20"
+    )
+
+    WishCard(
+        wishProduct = wishProduct,
+        targetPriceText = "추적중",
+        targetPriceColor = Color(0xFF3B82F6),
+        onTargetPriceButtonClick = {},
+        onRemove = {}
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 # Koin
 koin-bom = { module = "io.insert-koin:koin-bom", version.ref = "koin-bom" }
 koin-core = { module = "io.insert-koin:koin-core" }


### PR DESCRIPTION
## 관련 이슈

- close #30 

## 작업 내용

- `GetWishesUseCase` 정의
- `WishRepository`의 getWishes 추상메서드 반환형 수정
- `MockWishRepositoryImpl`의 getWishes 메서드 수정

### 주요 변경사항

1. 즐겨찾기 목록 조회 UseCase 구현

## 스크린샷
