### PR TITLE
#25 feat(search): 상품 아이템 Composable 분리

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/component/ProductItem.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/component/ProductItem.kt
@@ -1,0 +1,148 @@
+package com.hkjj.heartbreakprice.presentation.component
+
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.hkjj.heartbreakprice.domain.model.Product
+import java.text.NumberFormat
+import java.util.*
+
+@Composable
+fun ProductItem(
+    product: Product,
+    isFavorite: Boolean,
+    onToggleFavorite: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(8.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(modifier = Modifier.padding(16.dp)) {
+            // Product Image
+            AsyncImage(
+                model = product.image,
+                contentDescription = product.name,
+                modifier = Modifier
+                    .size(96.dp) // sm:size-32 usually 128px, using 96dp approx
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color.Gray),
+                contentScale = ContentScale.Crop
+            )
+
+            Spacer(modifier = Modifier.width(16.dp))
+
+            // Product Info
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    // Category Badge
+                    Box(
+                        modifier = Modifier
+                            .background(Color.White, RoundedCornerShape(4.dp))
+                            .padding(end = 8.dp)
+                    ) {
+                        Text(
+                            text = product.category,
+                            style = MaterialTheme.typography.labelSmall,
+                            modifier = Modifier.border(1.dp, Color.LightGray, RoundedCornerShape(4.dp))
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+
+                    // Discount Badge
+                    product.originalPrice?.let { original ->
+                        val discount = ((1 - product.price.toDouble() / original) * 100).toInt()
+                        Box(
+                            modifier = Modifier
+                                .background(Color.Red, RoundedCornerShape(4.dp))
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        ) {
+                            Text(
+                                text = "$discount% 할인",
+                                color = Color.White,
+                                style = MaterialTheme.typography.labelSmall
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                Text(
+                    text = product.name,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Medium,
+                    maxLines = 2
+                )
+                Text(
+                    text = product.shop,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Column {
+                        product.originalPrice?.let {
+                            Text(
+                                text = "${NumberFormat.getNumberInstance(Locale.KOREA).format(it)}원",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color.Gray,
+                                textDecoration = TextDecoration.LineThrough
+                            )
+                        }
+                        Text(
+                            text = "${NumberFormat.getNumberInstance(Locale.KOREA).format(product.price)}원",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                    Button(
+                        onClick = onToggleFavorite,
+                        contentPadding = PaddingValues(0.dp),
+                        modifier = Modifier
+                            .size(32.dp),
+                        shape = RoundedCornerShape(4.dp),
+                        colors = if (isFavorite) {
+                            ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        } else {
+                            ButtonDefaults.outlinedButtonColors()
+                        },
+                        border = if (!isFavorite) androidx.compose.foundation.BorderStroke(1.dp, Color.LightGray) else null
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Favorite,
+                            contentDescription = "Favorite",
+                            tint = if (isFavorite) Color.White else Color.Gray,
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchScreen.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchScreen.kt
@@ -1,7 +1,7 @@
 package com.hkjj.heartbreakprice.presentation.screen.search
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
@@ -10,24 +10,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import coil.compose.AsyncImage
-import com.hkjj.heartbreakprice.domain.model.Product
-import java.text.NumberFormat
+import com.hkjj.heartbreakprice.presentation.component.ProductItem
 import java.util.*
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -84,7 +78,7 @@ fun SearchScreen(
                         containerColor = if (isSelected) MaterialTheme.colorScheme.primary else Color.White,
                         contentColor = if (isSelected) Color.White else Color.Black
                     ),
-                    border = if (isSelected) null else androidx.compose.foundation.BorderStroke(1.dp, Color.LightGray),
+                    border = if (isSelected) null else BorderStroke(1.dp, Color.LightGray),
                     contentPadding = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
                     modifier = Modifier.height(32.dp)
                 ) {
@@ -118,127 +112,11 @@ fun SearchScreen(
     }
 }
 
+@Preview
 @Composable
-fun ProductItem(
-    product: Product,
-    isFavorite: Boolean,
-    onToggleFavorite: () -> Unit
-) {
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(8.dp),
-        colors = CardDefaults.cardColors(containerColor = Color.White),
-        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
-    ) {
-        Row(modifier = Modifier.padding(16.dp)) {
-            // Product Image
-            AsyncImage(
-                model = product.image,
-                contentDescription = product.name,
-                modifier = Modifier
-                    .size(96.dp) // sm:size-32 usually 128px, using 96dp approx
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(Color.Gray),
-                contentScale = ContentScale.Crop
-            )
-
-            Spacer(modifier = Modifier.width(16.dp))
-
-            // Product Info
-            Column(modifier = Modifier.weight(1f)) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    // Category Badge
-                    Box(
-                        modifier = Modifier
-                            .background(Color.White, RoundedCornerShape(4.dp))
-                            .padding(end = 8.dp)
-                    ) {
-                        Text(
-                            text = product.category,
-                            style = MaterialTheme.typography.labelSmall,
-                            modifier = Modifier.border(1.dp, Color.LightGray, RoundedCornerShape(4.dp))
-                                .padding(horizontal = 6.dp, vertical = 2.dp)
-                        )
-                    }
-
-                    // Discount Badge
-                    product.originalPrice?.let { original ->
-                        val discount = ((1 - product.price.toDouble() / original) * 100).toInt()
-                        Box(
-                            modifier = Modifier
-                                .background(Color.Red, RoundedCornerShape(4.dp))
-                                .padding(horizontal = 6.dp, vertical = 2.dp)
-                        ) {
-                            Text(
-                                text = "$discount% 할인",
-                                color = Color.White,
-                                style = MaterialTheme.typography.labelSmall
-                            )
-                        }
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(4.dp))
-
-                Text(
-                    text = product.name,
-                    style = MaterialTheme.typography.titleSmall,
-                    fontWeight = FontWeight.Medium,
-                    maxLines = 2
-                )
-                Text(
-                    text = product.shop,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color.Gray
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Column {
-                        product.originalPrice?.let {
-                            Text(
-                                text = "${NumberFormat.getNumberInstance(Locale.KOREA).format(it)}원",
-                                style = MaterialTheme.typography.bodySmall,
-                                color = Color.Gray,
-                                textDecoration = TextDecoration.LineThrough
-                            )
-                        }
-                        Text(
-                            text = "${NumberFormat.getNumberInstance(Locale.KOREA).format(product.price)}원",
-                            style = MaterialTheme.typography.titleMedium,
-                            fontWeight = FontWeight.Bold
-                        )
-                    }
-                    Button(
-                        onClick = onToggleFavorite,
-                        contentPadding = PaddingValues(0.dp),
-                        modifier = Modifier
-                            .size(32.dp),
-                        shape = RoundedCornerShape(4.dp),
-                        colors = if (isFavorite) {
-                            ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
-                        } else {
-                            ButtonDefaults.outlinedButtonColors()
-                        },
-                        border = if (!isFavorite) androidx.compose.foundation.BorderStroke(1.dp, Color.LightGray) else null
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.Favorite,
-                            contentDescription = "Favorite",
-                            tint = if (isFavorite) Color.White else Color.Gray,
-                            modifier = Modifier.size(16.dp)
-                        )
-                    }
-                }
-            }
-        }
-    }
+private fun SearchScreenPreview() {
+    SearchScreen(
+        uiState = SearchUiState(),
+        onSearchAction = {},
+    )
 }


### PR DESCRIPTION
## 관련 이슈

- close #25 

## 작업 내용

- `SearchScreen.kt`에 있던 `ProductItem` 컴포저블을 `presentation/component/ProductItem.kt` 파일로 분리
- `SearchScreen.kt`에서는 분리된 컴포저블을 import하여 사용하도록 수정함
- `SearchScreen.kt`에 `@Preview` 추가 

### 주요 변경사항

1. 상품 아이템 Composable 분리