### PR TITLE
feat(navigation): 찜 목록 화면 연결

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hkjj.heartbreakprice.core.routing.NavigationAction
 import com.hkjj.heartbreakprice.presentation.screen.search.SearchRoot
+import com.hkjj.heartbreakprice.presentation.screen.wish.WishRoot
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -81,7 +82,7 @@ fun MainRoot(
             modifier = Modifier.padding(innerPadding)
         ) {
             composable("search") { SearchRoot() }
-            composable("wish") { Text("Wish") }
+            composable("wish") { WishRoot() }
             composable("notification") { Text("Notification") }
             composable("settings") { Text("Settings") }
         }


### PR DESCRIPTION
## 관련 이슈

- close #50 

## 작업 내용

- 메인 네비게이션 그래프의 "wish" 경로에 `WishRoot` 컴포넌트를 연결하여 찜 목록 화면을 구현함

### 주요 변경사항

1. MainRoot NavHost에 WishRoot 연결

## 스크린샷
