### PR TITLE
refactor(auth): 의존성 주입 방식 및 내비게이션 경로 수정

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationViewModel.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationViewModel.kt
@@ -2,7 +2,7 @@ package com.hkjj.heartbreakprice.core.routing
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hkjj.heartbreakprice.data.repository.AuthRepositoryImpl
+import com.hkjj.heartbreakprice.domain.repository.AuthRepository
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class NavigationViewModel(
-    private val authRepository: AuthRepositoryImpl
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(NavigationUiState())

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
@@ -20,6 +20,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.hkjj.heartbreakprice.core.routing.NavigationAction
 import com.hkjj.heartbreakprice.presentation.screen.search.SearchRoot
+import com.hkjj.heartbreakprice.presentation.screen.setting.SettingRoot
 import com.hkjj.heartbreakprice.presentation.screen.wish.WishRoot
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -84,7 +85,7 @@ fun MainRoot(
             composable("search") { SearchRoot() }
             composable("wish") { WishRoot() }
             composable("notification") { Text("Notification") }
-            composable("settings") { Text("Settings") }
+            composable("settings") { SettingRoot(onLogout = { }) }
         }
     }
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/signin/SignInViewModel.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/signin/SignInViewModel.kt
@@ -2,7 +2,7 @@ package com.hkjj.heartbreakprice.presentation.screen.signin
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hkjj.heartbreakprice.data.repository.AuthRepositoryImpl
+import com.hkjj.heartbreakprice.domain.repository.AuthRepository
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class SignInViewModel(
-    private val authRepository: AuthRepositoryImpl
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SignInUiState())

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/signup/SignUpViewModel.kt
@@ -2,7 +2,7 @@ package com.hkjj.heartbreakprice.presentation.screen.signup
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.hkjj.heartbreakprice.data.repository.AuthRepositoryImpl
+import com.hkjj.heartbreakprice.domain.repository.AuthRepository
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class SignUpViewModel(
-    private val authRepository: AuthRepositoryImpl
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SignUpUiState())


### PR DESCRIPTION



## 작업 내용

- ViewModel이 구현체(`AuthRepositoryImpl`) 대신 인터페이스(`AuthRepository`)를 참조하도록 리팩토링하여 결합도를 낮춤
- 메인 화면의 설정(settings) 경로에 `SettingRoot` 컴포저블을 연결하여 화면 전환 로직을 구체화함


### 주요 변경사항

1. 의존성 주입 방식 및 내비게이션 경로 수정

## 스크린샷
