### PR TITLE
#91 feat(fcm): FCM 토큰 업데이트 기능 구현

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/data/repository/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/repository/AuthRepositoryImpl.kt
@@ -67,8 +67,8 @@ class AuthRepositoryImpl : AuthRepository {
     }
 
     override suspend fun updateFcmToken(token: String) {
-        // TODO firestore Token Update
-        return Unit
+        val uid = auth.currentUser?.uid ?: return
+        firestore.collection("Users").document(uid).update("fcmToken", token).await()
     }
 }
 


### PR DESCRIPTION

## 관련 이슈

- close #91 

## 작업 내용

- AuthRepositoryImpl의 `updateFcmToken` 메서드에서 Firestore의 "Users" 컬렉션에 FCM 토큰을 업데이트하는 로직을 구현함
- 현재 로그인된 사용자의 UID를 기반으로 해당 문서의 `fcmToken` 필드를 갱신함


### 주요 변경사항

1.  FCM 토큰 업데이트 기능 구현

## 스크린샷
