### PR TITLE
feature/remote-search: 검색 로직을 디바운스 대신 명시적 이벤트로 변경 

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchAction.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchAction.kt
@@ -6,4 +6,5 @@ sealed interface SearchAction {
     data class AddToFavorite(val product: Product) : SearchAction
     data class OnChangeSearchTerm(val searchTerm: String) : SearchAction
     data class CategoryClick(val category: String) : SearchAction
+    data object OnSearch : SearchAction
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchScreen.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchScreen.kt
@@ -47,8 +47,13 @@ fun SearchScreen(
                 .fillMaxWidth()
                 .padding(bottom = 24.dp),
             placeholder = { Text("상품명을 검색하세요...") },
-            leadingIcon = {
-                Icon(Icons.Default.Search, contentDescription = "Search", tint = Color.Gray)
+            trailingIcon = {
+                IconButton(onClick = {
+                    onSearchAction(SearchAction.OnSearch)
+                    focusManager.clearFocus()
+                }) {
+                    Icon(Icons.Default.Search, contentDescription = "Search", tint = Color.Gray)
+                }
             },
             singleLine = true,
             shape = RoundedCornerShape(8.dp),
@@ -57,8 +62,11 @@ fun SearchScreen(
                 unfocusedIndicatorColor = Color.Transparent,
                 disabledIndicatorColor = Color.Transparent
             ),
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() })
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = {
+                onSearchAction(SearchAction.OnSearch)
+                focusManager.clearFocus()
+            })
         )
 
         // Category Filter

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchViewModel.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchViewModel.kt
@@ -49,7 +49,6 @@ class SearchViewModel(
             }
         }
 
-        observeSearchTerm()
     }
 
     fun onAction(action: SearchAction) {
@@ -92,22 +91,16 @@ class SearchViewModel(
             is SearchAction.OnChangeSearchTerm -> {
                 _uiState.value = _uiState.value.copy(searchTerm = action.searchTerm)
             }
-        }
-    }
-
-    private fun observeSearchTerm() {
-        viewModelScope.launch {
-            _uiState
-                .map { it.searchTerm }
-                .debounce(300)
-                .collect { query ->
-                    val result = getSearchedProductUseCase(query)
+            is SearchAction.OnSearch -> {
+                viewModelScope.launch {
+                    val result = getSearchedProductUseCase(_uiState.value.searchTerm)
                     if (result is Result.Success) {
                         allProducts = result.data
                         updateCategories()
                         updateFilteredProducts()
                     }
                 }
+            }
         }
     }
 

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchViewModel.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchViewModel.kt
@@ -107,7 +107,7 @@ class SearchViewModel(
     private fun updateCategories() {
         val uniqueCategories = allProducts.map { it.brand }.distinct().filter { it.isNotBlank() }
         val hasEmptyBrand = allProducts.any { it.brand.isBlank() }
-        val finalCategories = if (hasEmptyBrand) {
+        val finalCategories = if (hasEmptyBrand && uniqueCategories.isNotEmpty()) {
             listOf("전체") + uniqueCategories + "기타"
         } else {
             listOf("전체") + uniqueCategories


### PR DESCRIPTION
## 관련 이슈

- close #94 

## 작업 내용

- 검색 로직을 디바운스 대신 클릭 이벤트로 변경 
- 카테고리 필터의 `기타` 항목 표시 로직 수정

### 주요 변경사항

1. `SearchViewModel`에서 `debounce`를 사용한 자동 검색 로직(`observeSearchTerm`)을 제거
2. 사용자가 검색 버튼을 클릭하거나 키보드의 검색 액션을 실행할 때만 검색이 수행되도록 `OnSearch` 액션을 정의하고 관련 로직을 수정
3. `SearchViewModel`의 `updateCategories` 메서드에서 브랜드가 없는 상품만 존재할 경우, `기타` 카테고리가 불필요하게 표시되는 조건을 수정
