### PR TITLE
fix(wish): 목표가 수정 시 firestore에 반영되지 않는 이슈 해결

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/UseCaseModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/UseCaseModule.kt
@@ -12,6 +12,7 @@ import com.hkjj.heartbreakprice.domain.usecase.ReadAsMarkNotificationUseCase
 import com.hkjj.heartbreakprice.domain.usecase.LogoutUseCase
 import com.hkjj.heartbreakprice.domain.usecase.SignUpUseCase
 import com.hkjj.heartbreakprice.domain.usecase.UpdateFcmTokenUseCase
+import com.hkjj.heartbreakprice.domain.usecase.UpdateTargetPriceUseCase
 import org.koin.dsl.module
 
 val usecaseModule = module {
@@ -27,4 +28,5 @@ val usecaseModule = module {
     factory { SignUpUseCase(get()) }
     factory { UpdateFcmTokenUseCase(get(), get()) }
     factory { GetSignInStatusUseCase(get()) }
+    factory { UpdateTargetPriceUseCase(get()) }
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/ViewModelModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/ViewModelModule.kt
@@ -45,7 +45,8 @@ val viewModelModule = module {
         WishViewModel(
             addWishUseCase = get(),
             deleteWishUseCase = get(),
-            getWishesUseCase = get()
+            getWishesUseCase = get(),
+            updateTargetPriceUseCase = get()
         )
     }
 

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/UpdateTargetPriceUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/UpdateTargetPriceUseCase.kt
@@ -1,0 +1,11 @@
+package com.hkjj.heartbreakprice.domain.usecase
+
+import com.hkjj.heartbreakprice.domain.repository.WishRepository
+
+class UpdateTargetPriceUseCase(
+    private val wishRepository: WishRepository
+) {
+    suspend operator fun invoke(productId: String, targetPrice: Int) {
+        wishRepository.updateTargetPrice(productId, targetPrice)
+    }
+}


### PR DESCRIPTION


## 관련 이슈

- close #88 

## 작업 내용

- `UpdateTargetPriceUseCase`를 추가하여 목표 가격 수정을 위한 도메인 로직 구현
- `UseCaseModule` 및 `ViewModelModule`에 `UpdateTargetPriceUseCase` 의존성 주입 설정 추가
- `WishViewModel`에서 목표가 변경 시 낙관적 업데이트(Optimistic Update) 적용 및 API 호출 로직 연동
- API 호출 실패 시 에러 메시지를 상태에 반영하도록 예외 처리 추가

### 주요 변경사항

1. 목표가 수정 시 firestore에 반영되지 않는 이슈 해결


## 스크린샷
