### PR TITLE
fix(wish): 추적중과 목표가 도달 표시가 서로 반대로 나타나는 현상 수정

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/wish/WishScreen.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/wish/WishScreen.kt
@@ -88,11 +88,11 @@ fun WishScreen(
                         onRemove = {
                             onAction(WishAction.OnDeleteClick(product.id))
                         },
-                        targetPriceText = if (product.price <= product.targetPrice) "추적중" else "목표가 도달",
+                        targetPriceText = if (product.price <= product.targetPrice) "목표가 도달" else "추적중",
                         targetPriceColor = if (product.price <= product.targetPrice) {
-                            Color(0xFF3B82F6)
-                        } else {
                             Color(0xFF22C55E)
+                        } else {
+                            Color(0xFF3B82F6)
                         },
                         onTargetPriceButtonClick = { onAction(WishAction.OnShowDialog(product.id)) }
                     )


### PR DESCRIPTION

## 관련 이슈

- close #89 

## 작업 내용

- 현재 가격이 목표가보다 낮거나 같을 때(product.price <= product.targetPrice)의 상태 텍스트를 "추적중"에서 "목표가 도달"로 수정함
- 상태 텍스트 변경에 맞춰 "목표가 도달" 시 초록색(0xFF22C55E), "추적중"일 때 파란색(0xFF3B82F6)이 적용되도록 색상 로직을 반전시킴


### 주요 변경사항

1. 추적중과 목표가 도달 표시가 서로 반대로 나타나는 현상 수정
2. 
3. 

## 스크린샷
