### PR TITLE
feat(notification): 발송된 알림내역 알림 및 알림 삭제 기능 구현

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/DataSourceModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/DataSourceModule.kt
@@ -5,6 +5,7 @@ import com.hkjj.heartbreakprice.data.data_source.local.MockNotificationHistoryDa
 import com.hkjj.heartbreakprice.data.data_source.local.MockProductDataSourceImpl
 import com.hkjj.heartbreakprice.data.data_source.NotificationHistoryDataSource
 import com.hkjj.heartbreakprice.data.data_source.ProductDataSource
+import com.hkjj.heartbreakprice.data.data_source.remote.RemoteNotificationHistoryDataSourceImpl
 import com.hkjj.heartbreakprice.data.data_source.remote.RemoteProductDataSourceImpl
 import com.hkjj.heartbreakprice.data.data_source.remote.api.NaverShoppingApi
 import kotlinx.serialization.json.Json
@@ -15,11 +16,8 @@ import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 
 val datasourceModule = module {
-    single<NotificationHistoryDataSource> {
-        MockNotificationHistoryDataSourceImpl()
-    }
-
     if (BuildConfig.FLAVOR == "prod") {
+        single<NotificationHistoryDataSource> { RemoteNotificationHistoryDataSourceImpl() }
         single {
             val json = Json {
                 ignoreUnknownKeys = true // DTO에 정의되지 않은 필드는 무시
@@ -35,6 +33,7 @@ val datasourceModule = module {
         }
         single<ProductDataSource> { RemoteProductDataSourceImpl(get()) }
     } else {
+        single<NotificationHistoryDataSource> { MockNotificationHistoryDataSourceImpl() }
         single<ProductDataSource> { MockProductDataSourceImpl() }
     }
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/UseCaseModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/UseCaseModule.kt
@@ -2,6 +2,7 @@ package com.hkjj.heartbreakprice.core.di
 
 import com.hkjj.heartbreakprice.domain.usecase.AddWishUseCase
 import com.hkjj.heartbreakprice.domain.usecase.DeleteFcmTokenUseCase
+import com.hkjj.heartbreakprice.domain.usecase.DeleteNotificationUseCase
 import com.hkjj.heartbreakprice.domain.usecase.DeleteWishUseCase
 import com.hkjj.heartbreakprice.domain.usecase.GetNotificationHistoryUseCase
 import com.hkjj.heartbreakprice.domain.usecase.GetSearchedProductUseCase
@@ -20,6 +21,7 @@ val usecaseModule = module {
     factory { GetSearchedProductUseCase(get()) }
     factory { AddWishUseCase(get()) }
     factory { DeleteWishUseCase(get()) }
+    factory { DeleteNotificationUseCase(get()) }
     factory { GetWishesUseCase(get()) }
     factory { GetNotificationHistoryUseCase(get()) }
     factory { ReadAsMarkNotificationUseCase(get()) }

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/ViewModelModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/ViewModelModule.kt
@@ -55,7 +55,8 @@ val viewModelModule = module {
             readAsMarkNotificationUseCase = get(),
             getUserUseCase = get(),
             updateFcmTokenUseCase = get(),
-            deleteFcmTokenUseCase = get()
+            deleteFcmTokenUseCase = get(),
+            deleteNotificationUseCase = get()
         )
     }
     

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/NotificationHistoryDataSource.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/NotificationHistoryDataSource.kt
@@ -6,4 +6,6 @@ interface NotificationHistoryDataSource {
     suspend fun getAllNotificationHistories(): List<Notification>
 
     suspend fun readAsMarkNotification(id: String)
+
+    suspend fun deleteNotification(id: String)
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/MockNotificationHistoryDataSourceImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/MockNotificationHistoryDataSourceImpl.kt
@@ -50,4 +50,8 @@ class MockNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
     override suspend fun readAsMarkNotification(id: String) {
         mockNotifications.map { if (it.id == id) it.copy(isRead = !it.isRead) else it }
     }
+
+    override suspend fun deleteNotification(id: String) {
+        // Mock implementation
+    }
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/remote/RemoteNotificationHistoryDataSourceImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/remote/RemoteNotificationHistoryDataSourceImpl.kt
@@ -1,0 +1,78 @@
+package com.hkjj.heartbreakprice.data.data_source.remote
+
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.hkjj.heartbreakprice.data.data_source.NotificationHistoryDataSource
+import com.hkjj.heartbreakprice.domain.model.Notification
+import com.hkjj.heartbreakprice.domain.model.NotificationType
+import kotlinx.coroutines.tasks.await
+
+class RemoteNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
+    private val auth = FirebaseAuth.getInstance()
+    private val firestore = FirebaseFirestore.getInstance("heart-break-price")
+
+    override suspend fun getAllNotificationHistories(): List<Notification> {
+        val uid = auth.currentUser?.uid ?: return emptyList()
+
+        return try {
+            val snapshot = firestore.collection("Users")
+                .document(uid)
+                .collection("notifications")
+                .orderBy("timestamp", Query.Direction.DESCENDING)
+                .get()
+                .await()
+
+            snapshot.documents.mapNotNull { doc ->
+                val typeStr = doc.getString("type") ?: return@mapNotNull null
+                val type = try {
+                    NotificationType.valueOf(typeStr)
+                } catch (e: Exception) {
+                    NotificationType.PRICE_DROP // 기본값
+                }
+
+                Notification(
+                    id = doc.id,
+                    type = type,
+                    productName = doc.getString("productName") ?: "",
+                    productImage = doc.getString("productImage") ?: "",
+                    message = doc.getString("message") ?: "",
+                    timestamp = doc.getDate("timestamp") ?: java.util.Date(),
+                    isRead = doc.getBoolean("isRead") ?: false,
+                    oldPrice = doc.getLong("oldPrice")?.toInt(),
+                    newPrice = doc.getLong("newPrice")?.toInt()
+                )
+            }
+        } catch (e: Exception) {
+            emptyList()
+        }
+    }
+
+    override suspend fun readAsMarkNotification(id: String) {
+        val uid = auth.currentUser?.uid ?: return
+        try {
+            firestore.collection("Users")
+                .document(uid)
+                .collection("notifications")
+                .document(id)
+                .update("isRead", true)
+                .await()
+        } catch (e: Exception) {
+            // 에러 처리
+        }
+    }
+
+    override suspend fun deleteNotification(id: String) {
+        val uid = auth.currentUser?.uid ?: return
+        try {
+            firestore.collection("Users")
+                .document(uid)
+                .collection("notifications")
+                .document(id)
+                .delete()
+                .await()
+        } catch (e: Exception) {
+            // 에러 처리
+        }
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/repository/NotificationHistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/repository/NotificationHistoryRepositoryImpl.kt
@@ -7,11 +7,19 @@ import com.hkjj.heartbreakprice.domain.repository.NotificationHistoryRepository
 class NotificationHistoryRepositoryImpl(
     private val notificationHistoryDataSource: NotificationHistoryDataSource
 ) : NotificationHistoryRepository {
+    override suspend fun getAllNotificationHistories(): List<Notification> {
+        return notificationHistoryDataSource.getAllNotificationHistories()
+    }
+
     override suspend fun getUnreadNotificationHistories(): List<Notification> {
         return notificationHistoryDataSource.getAllNotificationHistories().filter { !it.isRead }
     }
 
     override suspend fun readAsMarkNotification(notificationId: String) {
         return notificationHistoryDataSource.readAsMarkNotification(notificationId)
+    }
+
+    override suspend fun deleteNotification(notificationId: String) {
+        return notificationHistoryDataSource.deleteNotification(notificationId)
     }
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/NotificationHistoryRepository.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/NotificationHistoryRepository.kt
@@ -3,7 +3,11 @@ package com.hkjj.heartbreakprice.domain.repository
 import com.hkjj.heartbreakprice.domain.model.Notification
 
 interface NotificationHistoryRepository {
+    suspend fun getAllNotificationHistories(): List<Notification>
+
     suspend fun getUnreadNotificationHistories(): List<Notification>
 
     suspend fun readAsMarkNotification(notificationId: String)
+
+    suspend fun deleteNotification(notificationId: String)
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/DeleteNotificationUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/DeleteNotificationUseCase.kt
@@ -1,0 +1,17 @@
+package com.hkjj.heartbreakprice.domain.usecase
+
+import com.hkjj.heartbreakprice.core.Result
+import com.hkjj.heartbreakprice.domain.repository.NotificationHistoryRepository
+
+class DeleteNotificationUseCase(
+    private val repository: NotificationHistoryRepository
+) {
+    suspend operator fun invoke(notificationId: String): Result<Unit, Exception> {
+        return try {
+            repository.deleteNotification(notificationId)
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            Result.Error(e)
+        }
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetNotificationHistoryUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetNotificationHistoryUseCase.kt
@@ -9,7 +9,7 @@ class GetNotificationHistoryUseCase(
 ) {
     suspend operator fun invoke(): Result<List<Notification>, Exception> {
         return try {
-            val notificationHistories = notificationHistoryRepository.getUnreadNotificationHistories()
+            val notificationHistories = notificationHistoryRepository.getAllNotificationHistories()
             Result.Success(notificationHistories)
         } catch (e: Exception) {
             Result.Error(e)


### PR DESCRIPTION


## 관련 이슈

- close #{Issue Number}

## 작업 내용

- Firestore를 사용해 알림을 삭제하는 `DeleteNotificationUseCase` 및 관련 데이터 소스, 레포지토리 로직을 구현함
- 알림 목록을 가져올 때 기존에 읽지 않은 알림만 가져오던 것을 전체 알림을 가져오도록 수정함
- `NotificationViewModel`에 알림 삭제 로직을 반영하고, 삭제 실패 시 에러 처리 및 목록을 다시 불러오는 기능을 추가함
- 'prod' 빌드에서는 `RemoteNotificationHistoryDataSourceImpl` (Firestore)를, 그 외에는 `MockNotificationHistoryDataSourceImpl`를 사용하도록 의존성 주입을 설정함

### 주요 변경사항

1. firestore에 저장된 발송된 알림내역 가져오는 기능 구현
2. 알림 삭제 기능 구현 및 firestore와 연동
3. 

## 스크린샷
