### PR TITLE
 refactor: Firestore 컬렉션 명칭 notification에서 Notification으로 변경

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/remote/RemoteNotificationHistoryDataSourceImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/remote/RemoteNotificationHistoryDataSourceImpl.kt
@@ -18,7 +18,7 @@ class RemoteNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
         return try {
             val snapshot = firestore.collection("Users")
                 .document(uid)
-                .collection("Notification")
+                .collection("Notifications")
                 .orderBy("timestamp", Query.Direction.DESCENDING)
                 .get()
                 .await()
@@ -53,7 +53,7 @@ class RemoteNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
         try {
             firestore.collection("Users")
                 .document(uid)
-                .collection("Notification")
+                .collection("Notifications")
                 .document(id)
                 .update("isRead", true)
                 .await()
@@ -67,7 +67,7 @@ class RemoteNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
         try {
             firestore.collection("Users")
                 .document(uid)
-                .collection("Notification")
+                .collection("Notifications")
                 .document(id)
                 .delete()
                 .await()

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/remote/RemoteNotificationHistoryDataSourceImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/remote/RemoteNotificationHistoryDataSourceImpl.kt
@@ -18,7 +18,7 @@ class RemoteNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
         return try {
             val snapshot = firestore.collection("Users")
                 .document(uid)
-                .collection("notifications")
+                .collection("Notification")
                 .orderBy("timestamp", Query.Direction.DESCENDING)
                 .get()
                 .await()
@@ -53,7 +53,7 @@ class RemoteNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
         try {
             firestore.collection("Users")
                 .document(uid)
-                .collection("notifications")
+                .collection("Notification")
                 .document(id)
                 .update("isRead", true)
                 .await()
@@ -67,7 +67,7 @@ class RemoteNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
         try {
             firestore.collection("Users")
                 .document(uid)
-                .collection("notifications")
+                .collection("Notification")
                 .document(id)
                 .delete()
                 .await()

--- a/cloud-function/functions/src/index.ts
+++ b/cloud-function/functions/src/index.ts
@@ -146,7 +146,7 @@ async function notifyUsersIfNeeded(
         `${currentPrice.toLocaleString()}원`;
 
       /** 1️⃣ Firestore notifications 저장 */
-      await userDocRef.collection("notifications").add({
+      await userDocRef.collection("Notifications").add({
         type: "TARGET_REACHED",
         productName,
         productImage,


### PR DESCRIPTION
## 관련 이슈

- close #{Issue Number}

## 작업 내용

- Firestore 컬렉션 명칭 notification에서 Notification으로 변경

### 주요 변경사항

1. Firestore 컬렉션 명칭 notification에서 Notification으로 변경
2. 
3. 

## 스크린샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 상품 검색 기능으로 쇼핑 플랫폼에서 상품을 검색할 수 있습니다.
  * 찜하기 및 목표 가격 설정 기능으로 원하는 상품을 저장하고 가격을 추적할 수 있습니다.
  * 가격 하락 알림 기능으로 목표 가격 이하로 내려가면 푸시 알림을 받습니다.
  * 계정 기능으로 회원가입, 로그인, 사용자 정보 관리가 가능합니다.

* **앱 개선**
  * 알림 관리 화면에서 모든 알림을 한 곳에서 확인하고 관리할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->