### PR TITLE
#106 feat: 로그아웃 기능 구현 및 네비게이션 로직 수정

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationAction.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationAction.kt
@@ -2,6 +2,7 @@ package com.hkjj.heartbreakprice.core.routing
 
 sealed interface NavigationAction {
     data object NavigateToSignUp : NavigationAction
+    data object NavigateToSignIn : NavigationAction
     data object NavigateToMain : NavigationAction
     data object NavigateBack : NavigationAction
     data class NavigateToDetail(val id: String) : NavigationAction

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationRoot.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationRoot.kt
@@ -29,7 +29,11 @@ fun NavigationRoot(
         viewModel.event.collectLatest { event ->
             when (event) {
                 is NavigationEvent.NavigateTo -> {
-                    navController.navigate(event.route)
+                    navController.navigate(event.route) {
+                        if (event.route is Route.SignIn) {
+                            popUpTo(0) { inclusive = true }
+                        }
+                    }
                 }
                 is NavigationEvent.NavigateBack -> {
                     navController.popBackStack()

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationViewModel.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationViewModel.kt
@@ -30,6 +30,9 @@ class NavigationViewModel(
                 is NavigationAction.NavigateToMain -> {
                     _event.send(NavigationEvent.NavigateTo(Route.Main))
                 }
+                is NavigationAction.NavigateToSignIn -> {
+                    _event.send(NavigationEvent.NavigateTo(Route.SignIn))
+                }
                 is NavigationAction.NavigateToSignUp -> {
                     _event.send(NavigationEvent.NavigateTo(Route.SignUp))
                 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/LogoutUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/LogoutUseCase.kt
@@ -8,6 +8,11 @@ class LogoutUseCase(
 ) {
     suspend operator fun invoke(): Result<Unit, Exception> {
         return try {
+            try {
+                authRepository.updateFcmToken("")
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
             authRepository.logout()
             Result.Success(Unit)
         } catch (e: Exception) {

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
@@ -86,7 +86,13 @@ fun MainRoot(
             composable("search") { SearchRoot() }
             composable("wish") { WishRoot() }
             composable("notification") { NotificationRoot() }
-            composable("settings") { SettingRoot(onLogout = { }) }
+            composable("settings") {
+                SettingRoot(
+                    onLogout = {
+                        onNavigationAction(NavigationAction.NavigateToSignIn)
+                    }
+                )
+            }
         }
     }
 }


### PR DESCRIPTION


## 관련 이슈

- close #106 

## 작업 내용

- `LogoutUseCase`에서 로그아웃 시 FCM 토큰을 초기화하도록 로직을 추가함
- `NavigationRoot`에서 `SignIn` 화면으로 이동할 때 기존 백스택을 모두 제거(`popUpTo(0)`)하도록 수정함
- `MainRoot`의 설정(Settings) 화면에서 로그아웃 콜백 시 로그인 화면으로 이동하는 액션을 연결함
- `NavigationAction` 및 `NavigationViewModel`에 로그인 화면 이동(`NavigateToSignIn`) 케이스를 추가함 

### 주요 변경사항

1. 로그아웃 기능 구현 및 네비게이션 로직 수정
2. 
3. 

## 스크린샷
