### PR TITLE
#108 fix: 로그인 성공 후 메인화면 진입하고 나서 뒤로가기 하면 로그인 화면이 나타나는 현상

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationRoot.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/routing/NavigationRoot.kt
@@ -30,7 +30,7 @@ fun NavigationRoot(
             when (event) {
                 is NavigationEvent.NavigateTo -> {
                     navController.navigate(event.route) {
-                        if (event.route is Route.SignIn) {
+                        if (event.route is Route.Main || event.route is Route.SignIn) {
                             popUpTo(0) { inclusive = true }
                         }
                     }
@@ -46,7 +46,6 @@ fun NavigationRoot(
         navController = navController,
         startDestination = Route.Entry,
     ) {
-
         composable<Route.Entry> {
             LaunchedEffect(uiState.isSignIn) {
                 val target: Route = if (uiState.isSignIn) {


### PR DESCRIPTION
## 관련 이슈

- close #108 

## 작업 내용

- 메인 화면으로 넘어갈때도 네비게이션 스택에서 쌓이지 않게 처리

### 주요 변경사항

1. 네비게이션 처리시 조건 변경
