### PR TITLE
#111 refactor(Notification): 알림 내역 조회를 Flow 기반의 실시간 데이터 구독 방식으로 변경

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/NotificationHistoryDataSource.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/NotificationHistoryDataSource.kt
@@ -1,9 +1,10 @@
 package com.hkjj.heartbreakprice.data.data_source
 
 import com.hkjj.heartbreakprice.domain.model.Notification
+import kotlinx.coroutines.flow.Flow
 
 interface NotificationHistoryDataSource {
-    suspend fun getAllNotificationHistories(): List<Notification>
+    fun getAllNotificationHistories(): Flow<List<Notification>>
 
     suspend fun readAsMarkNotification(id: String)
 

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/MockNotificationHistoryDataSourceImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/MockNotificationHistoryDataSourceImpl.kt
@@ -3,6 +3,8 @@ package com.hkjj.heartbreakprice.data.data_source.local
 import com.hkjj.heartbreakprice.data.data_source.NotificationHistoryDataSource
 import com.hkjj.heartbreakprice.domain.model.Notification
 import com.hkjj.heartbreakprice.domain.model.NotificationType
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import java.util.Date
 
 class MockNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
@@ -43,8 +45,8 @@ class MockNotificationHistoryDataSourceImpl : NotificationHistoryDataSource {
         )
     )
 
-    override suspend fun getAllNotificationHistories(): List<Notification> {
-        return mockNotifications
+    override fun getAllNotificationHistories(): Flow<List<Notification>> = flow {
+        emit(mockNotifications)
     }
 
     override suspend fun readAsMarkNotification(id: String) {

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/repository/NotificationHistoryRepositoryImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/repository/NotificationHistoryRepositoryImpl.kt
@@ -3,16 +3,19 @@ package com.hkjj.heartbreakprice.data.repository
 import com.hkjj.heartbreakprice.data.data_source.NotificationHistoryDataSource
 import com.hkjj.heartbreakprice.domain.model.Notification
 import com.hkjj.heartbreakprice.domain.repository.NotificationHistoryRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 class NotificationHistoryRepositoryImpl(
     private val notificationHistoryDataSource: NotificationHistoryDataSource
 ) : NotificationHistoryRepository {
-    override suspend fun getAllNotificationHistories(): List<Notification> {
+    override fun getAllNotificationHistories(): Flow<List<Notification>> {
         return notificationHistoryDataSource.getAllNotificationHistories()
     }
 
-    override suspend fun getUnreadNotificationHistories(): List<Notification> {
-        return notificationHistoryDataSource.getAllNotificationHistories().filter { !it.isRead }
+    override fun getUnreadNotificationHistories(): Flow<List<Notification>> {
+        return notificationHistoryDataSource.getAllNotificationHistories()
+            .map { notifications -> notifications.filter { !it.isRead } }
     }
 
     override suspend fun readAsMarkNotification(notificationId: String) {

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/NotificationHistoryRepository.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/NotificationHistoryRepository.kt
@@ -1,11 +1,12 @@
 package com.hkjj.heartbreakprice.domain.repository
 
 import com.hkjj.heartbreakprice.domain.model.Notification
+import kotlinx.coroutines.flow.Flow
 
 interface NotificationHistoryRepository {
-    suspend fun getAllNotificationHistories(): List<Notification>
+    fun getAllNotificationHistories(): Flow<List<Notification>>
 
-    suspend fun getUnreadNotificationHistories(): List<Notification>
+    fun getUnreadNotificationHistories(): Flow<List<Notification>>
 
     suspend fun readAsMarkNotification(notificationId: String)
 

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetNotificationHistoryUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetNotificationHistoryUseCase.kt
@@ -2,17 +2,12 @@ package com.hkjj.heartbreakprice.domain.usecase
 
 import com.hkjj.heartbreakprice.domain.model.Notification
 import com.hkjj.heartbreakprice.domain.repository.NotificationHistoryRepository
-import com.hkjj.heartbreakprice.core.Result
+import kotlinx.coroutines.flow.Flow
 
 class GetNotificationHistoryUseCase(
     private val notificationHistoryRepository: NotificationHistoryRepository
 ) {
-    suspend operator fun invoke(): Result<List<Notification>, Exception> {
-        return try {
-            val notificationHistories = notificationHistoryRepository.getAllNotificationHistories()
-            Result.Success(notificationHistories)
-        } catch (e: Exception) {
-            Result.Error(e)
-        }
+    operator fun invoke(): Flow<List<Notification>> {
+        return notificationHistoryRepository.getAllNotificationHistories()
     }
 }


### PR DESCRIPTION

## 관련 이슈

- close #108

## 작업 내용

- `NotificationHistoryDataSource` 및 `Repository`의 알림 조회 메서드 반환 타입을 `List<Notification>`에서 `Flow<List<Notification>>`으로 변경함
- `RemoteNotificationHistoryDataSourceImpl`에서 Firestore `addSnapshotListener`를 사용하여 알림 데이터의 실시간 변경 사항을 감지하도록 구현함
- `NotificationViewModel`에서 `fetchNotificationHistories`를 `observeNotificationHistories`로 변경하여 데이터 스트림을 구독하고 UI 상태를 자동 갱신하도록 수정함
- `GetNotificationHistoryUseCase`를 `suspend` 함수 대신 Flow를 반환하는 일반 함수로 변경하고, 관련 비즈니스 로직을 리팩토링함

### 주요 변경사항

1. 알림 내역 조회를 Flow 기반의 실시간 데이터 구독 방식으로 변경
2. 
3. 

## 스크린샷
