### PR TITLE
#116 feat: 가격변동 FCM발송 시 발송 결과를 디스코드로 받을 수 있는 기능 추가

### DIFF
--- a/cloud-function/functions/.eslintrc.js
+++ b/cloud-function/functions/.eslintrc.js
@@ -29,5 +29,8 @@ module.exports = {
     "quotes": ["error", "double"],
     "import/no-unresolved": 0,
     "indent": ["error", 2],
+    "linebreak-style": 0,
+    "max-len": 0,
+    "object-curly-spacing": ["error", "never"],
   },
 };


### PR DESCRIPTION

## 관련 이슈

- close #116 

## 작업 내용

- Discord 웹훅을 통해 알림 생성 및 FCM 발송 결과를 전송하는 `sendDiscordWebhook` 함수를 추가함
- `notifyUsersIfNeeded` 함수가 알림 생성, 전송 성공, 실패 횟수를 반환하도록 수정함
- 예약 실행 작업(scheduler) 종료 시 요약된 리포트를 Discord로 전송하고 상세 실행 로그를 남기도록 개선함
- `.eslintrc.js`에 `linebreak-style`, `max-len`, `object-curly-spacing` 규칙을 완화 또는 수정하여 코드 스타일 설정을 변경함

### 주요 변경사항

1. 가격변동 FCM발송 시 발송 결과를 디스코드로 받을 수 있는 기능 추가
2. 
3. 

## 스크린샷
<img width="640" height="307" alt="image" src="https://github.com/user-attachments/assets/3220c928-3cc5-4289-862a-02abe4d2579e" />

