### PR TITLE
feature/search-history: SharedPreferences 기반 최근 검색어 저장 및 로드 기능 구현

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/DataSourceModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/DataSourceModule.kt
@@ -14,8 +14,13 @@ import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
+import com.hkjj.heartbreakprice.data.data_source.local.SearchLocalDataSourceImpl
+import com.hkjj.heartbreakprice.data.data_source.SearchLocalDataSource
+import org.koin.android.ext.koin.androidContext
 
 val datasourceModule = module {
+    single<SearchLocalDataSource> { SearchLocalDataSourceImpl(androidContext()) }
+
     if (BuildConfig.FLAVOR == "prod") {
         single<NotificationHistoryDataSource> { RemoteNotificationHistoryDataSourceImpl() }
         single {

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/RepositoryModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/RepositoryModule.kt
@@ -9,8 +9,13 @@ import com.hkjj.heartbreakprice.domain.repository.NotificationHistoryRepository
 import com.hkjj.heartbreakprice.domain.repository.ProductRepository
 import com.hkjj.heartbreakprice.domain.repository.WishRepository
 import org.koin.dsl.module
+import com.hkjj.heartbreakprice.data.repository.SearchRepositoryImpl
+import com.hkjj.heartbreakprice.domain.repository.SearchRepository
 
 val repositoryModule = module {
+    single<SearchRepository> {
+        SearchRepositoryImpl(get())
+    }
     single<ProductRepository> {
         ProductRepositoryImpl(get())
     }

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/UseCaseModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/UseCaseModule.kt
@@ -16,6 +16,8 @@ import com.hkjj.heartbreakprice.domain.usecase.SignUpUseCase
 import com.hkjj.heartbreakprice.domain.usecase.UpdateFcmTokenUseCase
 import com.hkjj.heartbreakprice.domain.usecase.UpdateTargetPriceUseCase
 import org.koin.dsl.module
+import com.hkjj.heartbreakprice.domain.usecase.GetLastSearchTermUseCase
+import com.hkjj.heartbreakprice.domain.usecase.SaveLastSearchTermUseCase
 
 val usecaseModule = module {
     factory { GetSearchedProductUseCase(get()) }
@@ -33,4 +35,6 @@ val usecaseModule = module {
     factory { GetSignInStatusUseCase(get()) }
     factory { DeleteFcmTokenUseCase(get()) }
     factory { UpdateTargetPriceUseCase(get()) }
+    factory { SaveLastSearchTermUseCase(get()) }
+    factory { GetLastSearchTermUseCase(get()) }
 }

--- a/app/src/main/java/com/hkjj/heartbreakprice/core/di/ViewModelModule.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/core/di/ViewModelModule.kt
@@ -36,7 +36,9 @@ val viewModelModule = module {
             getSearchedProductUseCase = get(),
             addWishUseCase = get(),
             deleteWishUseCase = get(),
-            getWishesUseCase = get()
+            getWishesUseCase = get(),
+            saveLastSearchTermUseCase = get(),
+            getLastSearchTermUseCase = get()
         )
     }
     

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/SearchLocalDataSource.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/SearchLocalDataSource.kt
@@ -1,0 +1,6 @@
+package com.hkjj.heartbreakprice.data.data_source
+
+interface SearchLocalDataSource {
+    suspend fun saveLastSearchTerm(term: String)
+    suspend fun getLastSearchTerm(): String?
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/SearchLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/SearchLocalDataSourceImpl.kt
@@ -20,7 +20,7 @@ class SearchLocalDataSourceImpl(
     }
 
     override suspend fun saveLastSearchTerm(term: String) = withContext(Dispatchers.IO) {
-        prefs.edit {
+        prefs.edit(commit = true) {
             putString(KEY_LAST_SEARCH_TERM, term)
         }
     }

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/SearchLocalDataSourceImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/data_source/local/SearchLocalDataSourceImpl.kt
@@ -1,0 +1,31 @@
+package com.hkjj.heartbreakprice.data.data_source.local
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hkjj.heartbreakprice.data.data_source.SearchLocalDataSource
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class SearchLocalDataSourceImpl(
+    private val context: Context
+) : SearchLocalDataSource {
+
+    companion object {
+        private const val PREFS_NAME = "heartbreakprice_prefs"
+        private const val KEY_LAST_SEARCH_TERM = "last_search_term"
+    }
+
+    private val prefs by lazy {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    override suspend fun saveLastSearchTerm(term: String) = withContext(Dispatchers.IO) {
+        prefs.edit {
+            putString(KEY_LAST_SEARCH_TERM, term)
+        }
+    }
+
+    override suspend fun getLastSearchTerm(): String? = withContext(Dispatchers.IO) {
+        prefs.getString(KEY_LAST_SEARCH_TERM, null)
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/data/repository/SearchRepositoryImpl.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/data/repository/SearchRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.hkjj.heartbreakprice.data.repository
+
+import com.hkjj.heartbreakprice.data.data_source.SearchLocalDataSource
+import com.hkjj.heartbreakprice.domain.repository.SearchRepository
+
+class SearchRepositoryImpl(
+    private val searchLocalDataSource: SearchLocalDataSource
+) : SearchRepository {
+    override suspend fun saveLastSearchTerm(term: String) {
+        searchLocalDataSource.saveLastSearchTerm(term)
+    }
+
+    override suspend fun getLastSearchTerm(): String? {
+        return searchLocalDataSource.getLastSearchTerm()
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/SearchRepository.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/repository/SearchRepository.kt
@@ -1,0 +1,6 @@
+package com.hkjj.heartbreakprice.domain.repository
+
+interface SearchRepository {
+    suspend fun saveLastSearchTerm(term: String)
+    suspend fun getLastSearchTerm(): String?
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetLastSearchTermUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/GetLastSearchTermUseCase.kt
@@ -1,0 +1,11 @@
+package com.hkjj.heartbreakprice.domain.usecase
+
+import com.hkjj.heartbreakprice.domain.repository.SearchRepository
+
+class GetLastSearchTermUseCase(
+    private val searchRepository: SearchRepository
+) {
+    suspend operator fun invoke(): String? {
+        return searchRepository.getLastSearchTerm()
+    }
+}

--- a/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/SaveLastSearchTermUseCase.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/domain/usecase/SaveLastSearchTermUseCase.kt
@@ -1,0 +1,11 @@
+package com.hkjj.heartbreakprice.domain.usecase
+
+import com.hkjj.heartbreakprice.domain.repository.SearchRepository
+
+class SaveLastSearchTermUseCase(
+    private val searchRepository: SearchRepository
+) {
+    suspend operator fun invoke(term: String) {
+        searchRepository.saveLastSearchTerm(term)
+    }
+}


### PR DESCRIPTION
## 관련 이슈

- close #122 
- close #124 

## 작업 내용

- SharedPreferences 기반 최근 검색어 저장 및 로드 기능 구현

### 주요 변경사항

1. 로컬 data 계 및 UseCase 구축
   - SharedPreferences 기반의 SearchLocalDataSource와 관련 Repository 구현
   - 검색어 로드/저장을 위한 전용 UseCase(GetLastSearchTerm, SaveLastSearchTerm) 추가 및 Koin 모듈 등록
2. 화면 종료 시 데이터 저장 보장 (NonCancellable)
   - ViewModel의 onCleared() 시점에 코루틴이 취소되지 않도록 NonCancellable 컨텍스트를 적용하여 마지막 검색어 저장 로직의 완결성 확보
3. 동기식 저장 방식을 통한 데이터 무결성 확보
   - SharedPreferences 저장 시 apply() 대신 commit = true 옵션을 사용하여 데이터가 즉각적이고 확실하게 물리적으로 기록되도록 개선

