### PR TITLE
style(Theme): 앱 테마를 라이트 모드로 고정

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/ui/theme/Theme.kt
@@ -1,7 +1,6 @@
 package com.hkjj.heartbreakprice.ui.theme
 
 import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.dynamicDarkColorScheme
@@ -39,7 +38,7 @@ private val LightColorScheme = lightColorScheme(
 
 @Composable
 fun HeartBreakPriceTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    darkTheme: Boolean = false,
     // Dynamic color is available on Android 12+
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit


### PR DESCRIPTION


## 관련 이슈

- close #{Issue Number}

## 작업 내용

- `HeartBreakPriceTheme`의 `darkTheme` 매개변수 기본값을 `isSystemInDarkTheme()`에서 `false`로 변경하여 시스템 설정과 관계없이 라이트 테마가 적용되도록 수정함 

### 주요 변경사항

1. 앱 테마를 라이트 모드로 고정
2. 
3. 

## 스크린샷
