### PR TITLE
style(Search): MainRoot 및 SearchScreen UI 레이아웃 수정

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/main/MainRoot.kt
@@ -53,21 +53,7 @@ fun MainRoot(
     val isSelected = { route: String -> currentRoute?.destination?.route == route }
 
     Scaffold(
-        topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        stringResource(R.string.app_name),
-                        style = MaterialTheme.typography.titleLarge,
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                    containerColor = AppColors.White,
-                    titleContentColor = AppColors.Gray900
-                )
-            )
-        },
+
         bottomBar = {
             NavigationBar(
                 containerColor = AppColors.White

--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchScreen.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/search/SearchScreen.kt
@@ -50,7 +50,7 @@ fun SearchScreen(
                 style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
                 color = AppColors.Gray900,
-                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp, bottom = 8.dp)
+                modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 8.dp)
             )
         }
 


### PR DESCRIPTION

## 관련 이슈

- close #{Issue Number}

## 작업 내용

- `MainRoot.kt`에서 불필요한 `CenterAlignedTopAppBar`를 삭제하여 상단 바 제거
- `SearchScreen.kt`에서 상단 타이틀 텍스트의 `top padding` 값을 24.dp에서 16.dp로 조정하여 여백 최적화


### 주요 변경사항

1. MainRoot 및 SearchScreen UI 레이아웃 수정
2. 
3. 

## 스크린샷
