### PR TITLE
fix: 상태바 아이콘 색상 설정 로직 추가

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/ui/theme/Theme.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/ui/theme/Theme.kt
@@ -1,5 +1,6 @@
 package com.hkjj.heartbreakprice.ui.theme
 
+import android.app.Activity
 import android.os.Build
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
@@ -7,7 +8,10 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 import com.hkjj.heartbreakprice.ui.AppColors
 
 private val DarkColorScheme = darkColorScheme(
@@ -51,6 +55,14 @@ fun HeartBreakPriceTheme(
 
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = !darkTheme
+        }
     }
 
     MaterialTheme(


### PR DESCRIPTION


## 관련 이슈

- close #{Issue Number}

## 작업 내용

- `Theme.kt`에서 테마 모드(다크/라이트)에 따라 상태바 아이콘 색상이 적절하게 변경되도록 `WindowCompat` 설정을 추가함
- `SideEffect`를 사용하여 Compose 테마 변경 시 시스템 UI 외관이 동기화되도록 구현함

### 주요 변경사항

1. 상태바 아이콘 색상 설정 로직 추가
2. 
3. 

## 스크린샷
