### PR TITLE
style(notification): NotificationScreen 스크롤 수정

### DIFF
--- a/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/notification/NotificationScreen.kt
+++ b/app/src/main/java/com/hkjj/heartbreakprice/presentation/screen/notification/NotificationScreen.kt
@@ -30,87 +30,96 @@ fun NotificationScreen(
     val notifications = uiState.notifications
     val unreadCount = notifications.count { !it.isRead }
 
-    Column(
+    LazyColumn(
         modifier = Modifier
             .fillMaxSize()
-            .background(AppColors.Background)
-            .padding(16.dp)
+            .background(AppColors.Background),
+        contentPadding = PaddingValues(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         // Header
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 16.dp),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Column {
-                Text(
-                    text = stringResource(R.string.notification_title),
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.Bold,
-                    color = AppColors.Gray900
-                )
-                if (unreadCount > 0) {
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column {
                     Text(
-                        text = pluralStringResource(R.plurals.notification_unread_count, unreadCount, unreadCount),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = AppColors.Primary,
-                        fontWeight = FontWeight.Medium
+                        text = stringResource(R.string.notification_title),
+                        style = MaterialTheme.typography.headlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = AppColors.Gray900
                     )
+                    if (unreadCount > 0) {
+                        Text(
+                            text = pluralStringResource(
+                                R.plurals.notification_unread_count,
+                                unreadCount,
+                                unreadCount
+                            ),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = AppColors.Primary,
+                            fontWeight = FontWeight.Medium
+                        )
+                    }
                 }
-            }
-            if (notifications.isNotEmpty() && unreadCount > 0) {
-                TextButton(
-                    onClick = { onAction(NotificationAction.MarkAllAsRead) },
-                    colors = ButtonDefaults.textButtonColors(contentColor = AppColors.Primary)
-                ) {
-                    Text(stringResource(R.string.notification_mark_all_read), fontWeight = FontWeight.Bold)
+                if (notifications.isNotEmpty() && unreadCount > 0) {
+                    TextButton(
+                        onClick = { onAction(NotificationAction.MarkAllAsRead) },
+                        colors = ButtonDefaults.textButtonColors(contentColor = AppColors.Primary)
+                    ) {
+                        Text(
+                            stringResource(R.string.notification_mark_all_read),
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
                 }
             }
         }
-
-        Spacer(modifier = Modifier.height(16.dp))
 
         // Push Notification Setting
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(AppColors.White, shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp))
-                .padding(horizontal = 16.dp, vertical = 12.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = stringResource(R.string.notification_push_toggle),
-                style = MaterialTheme.typography.bodyMedium,
-                fontWeight = FontWeight.Medium
-            )
-            Switch(
-                checked = uiState.isPushEnabled,
-                onCheckedChange = { onAction(NotificationAction.TogglePushNotification(it)) },
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = AppColors.White,
-                    checkedTrackColor = AppColors.Primary
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        AppColors.White,
+                        shape = androidx.compose.foundation.shape.RoundedCornerShape(12.dp)
+                    )
+                    .padding(horizontal = 16.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    text = stringResource(R.string.notification_push_toggle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Medium
                 )
-            )
+                Switch(
+                    checked = uiState.isPushEnabled,
+                    onCheckedChange = { onAction(NotificationAction.TogglePushNotification(it)) },
+                    colors = SwitchDefaults.colors(
+                        checkedThumbColor = AppColors.White,
+                        checkedTrackColor = AppColors.Primary
+                    )
+                )
+            }
         }
 
-        Spacer(modifier = Modifier.height(16.dp))
-
         if (notifications.isEmpty()) {
-            EmptyNotificationItem()
+            item {
+                EmptyNotificationItem()
+            }
         } else {
-            LazyColumn(
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                items(notifications, key = { it.id }) { notification ->
-                    NotificationItem(
-                        notification = notification,
-                        onMarkAsRead = { onAction(NotificationAction.MarkAsRead(it)) },
-                        onDelete = { onAction(NotificationAction.DeleteNotification(it)) }
-                    )
-                }
+            items(notifications, key = { it.id }) { notification ->
+                NotificationItem(
+                    notification = notification,
+                    onMarkAsRead = { onAction(NotificationAction.MarkAsRead(it)) },
+                    onDelete = { onAction(NotificationAction.DeleteNotification(it)) }
+                )
             }
         }
     }


### PR DESCRIPTION

## 관련 이슈


## 작업 내용

- NotificationScreen 스크롤 수정

### 주요 변경사항

1. 기존의 `Column`과 내부의 `LazyColumn` 조합을 하나의 `LazyColumn`으로 통합하여 성능을 최적화하고 코드 구조를 단순화함
2. `LazyColumn`의 `item`을 활용하여 헤더, 푸시 알림 설정 토글, 알림 목록을 구성하도록 변경함
3. 항목 간 간격을 `Spacer` 대신 `LazyColumn`의 `verticalArrangement`와 `contentPadding`으로 일관성 있게 처리함
4. 푸시 알림 설정(`Switch`) 컴포넌트의 상하 `vertical` 패딩을 `12.dp`에서 `6.dp`로 조정함

## 스크린샷
